### PR TITLE
Add quick restock from part details modal

### DIFF
--- a/frontend/src/components/PartDetailsModal.js
+++ b/frontend/src/components/PartDetailsModal.js
@@ -16,6 +16,7 @@ import {
   Loader2,
   ChevronDown,
   ChevronUp,
+  PackagePlus,
 } from "lucide-react";
 import { fetchRestockHistory, returnRestockRecord, editRestockRecord } from "../services/api";
 
@@ -367,7 +368,7 @@ const RestockHistorySection = ({ partId, onRefresh }) => {
 };
 
 // ─── Main Modal ───────────────────────────────────────────────────────────────
-const PartDetailsModal = ({ part, onClose, onPartUpdated }) => {
+const PartDetailsModal = ({ part, onClose, onPartUpdated, onRestock }) => {
   if (!part) return null;
 
   const renderVehicleName = (v) => {
@@ -406,9 +407,20 @@ const PartDetailsModal = ({ part, onClose, onPartUpdated }) => {
           <h3 className="font-bold text-lg flex items-center gap-2">
             <Package size={20} /> Part Details
           </h3>
-          <button onClick={onClose} className="hover:bg-red-600 p-1 rounded-full transition-colors">
-            <XCircle size={20} />
-          </button>
+          <div className="flex items-center gap-2">
+            {onRestock && (
+              <button
+                onClick={() => { onClose(); onRestock(part); }}
+                className="flex items-center gap-1.5 bg-white/20 hover:bg-white/30 text-white text-xs font-bold px-3 py-1.5 rounded-lg border border-white/30 transition-colors"
+                title="Quick Restock this part"
+              >
+                <PackagePlus size={14} /> Restock
+              </button>
+            )}
+            <button onClick={onClose} className="hover:bg-red-600 p-1 rounded-full transition-colors">
+              <XCircle size={20} />
+            </button>
+          </div>
         </div>
 
         {/* Scrollable content */}

--- a/frontend/src/components/forms/QuickRestockModal.js
+++ b/frontend/src/components/forms/QuickRestockModal.js
@@ -121,15 +121,17 @@ const HistoryTab = ({ partId }) => {
 };
 
 // ─── Main Modal ───────────────────────────────────────────────────────────────
-const QuickRestockModal = ({ onClose, onSuccess }) => {
+const QuickRestockModal = ({ onClose, onSuccess, initialPart = null }) => {
   const [activeTab, setActiveTab] = useState("restock");
-  const [searchTerm, setSearchTerm] = useState("");
+  const [searchTerm, setSearchTerm] = useState(initialPart ? initialPart.name : "");
   const [searchResults, setSearchResults] = useState([]);
   const [searchLoading, setSearchLoading] = useState(false);
-  const [selectedPart, setSelectedPart] = useState(null);
+  const [selectedPart, setSelectedPart] = useState(initialPart);
   const [suppliers, setSuppliers] = useState([]);
 
-  const [entries, setEntries] = useState([emptyEntry()]);
+  const [entries, setEntries] = useState(
+    initialPart ? [{ ...emptyEntry(), buy_price: initialPart.buy_price || "" }] : [emptyEntry()]
+  );
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState("");
   const [fieldErrors, setFieldErrors] = useState({});

--- a/frontend/src/pages/InventoryPage.js
+++ b/frontend/src/pages/InventoryPage.js
@@ -256,6 +256,7 @@ const InventoryPage = () => {
   const fileInputRef = useRef(null);
   const [editingPart, setEditingPart] = useState(null);
   const [showRestockModal, setShowRestockModal] = useState(false);
+  const [restockInitialPart, setRestockInitialPart] = useState(null);
 
   // ── Filter States ────────────────────────────────────────────────────────
   const [searchTerm, setSearchTerm] = useState("");
@@ -487,12 +488,18 @@ const InventoryPage = () => {
         part={selectedPart}
         onClose={() => setSelectedPart(null)}
         onPartUpdated={invalidateParts}
+        onRestock={(part) => {
+          setSelectedPart(null);
+          setRestockInitialPart(part);
+          setShowRestockModal(true);
+        }}
       />
 
       {/* --- QUICK RESTOCK MODAL --- */}
       {showRestockModal && (
         <QuickRestockModal
-          onClose={() => setShowRestockModal(false)}
+          initialPart={restockInitialPart}
+          onClose={() => { setShowRestockModal(false); setRestockInitialPart(null); }}
           onSuccess={(msg) => {
             setAlertInfo({ type: "success", message: msg });
             invalidateParts();


### PR DESCRIPTION
Add an 'onRestock' callback to PartDetailsModal that pre-populates QuickRestockModal with the selected part's details (name and buy_price). Users can now quickly initiate a restock directly from the part details view without having to search for the part again. Includes a 'Restock' button in the modal header next to the close button.